### PR TITLE
chore(.gitignore): ignore node_modules folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
Adds a `.gitignore` file with an entry for the `node_modules` folder.